### PR TITLE
feat: 添加nginx构建命令支持本地部署

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
+    "build:nginx": "node scripts/build-nginx.js",
     "preview": "vitepress preview",
     "baiduPush": "tsx .scripts/baiduPush.ts https://vp.teek.top && bash .scripts/baiduPush.sh"
   },

--- a/docs/scripts/build-nginx.js
+++ b/docs/scripts/build-nginx.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+import { execSync } from "child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const docsDir = join(__dirname, "..");
+
+console.log("🚀 开始nginx构建流程...");
+console.log("📁 构建目录:", docsDir);
+
+function processFile(filePath) {
+  try {
+    const content = readFileSync(filePath, "utf8");
+    const newContent = content.replace(/\/universal-iot-docs\//g, "/");
+
+    if (content !== newContent) {
+      writeFileSync(filePath, newContent);
+      console.log(`✅ 修复文件: ${filePath}`);
+    }
+  } catch (error) {
+    console.error(`❌ 处理文件失败: ${filePath}`, error.message);
+  }
+}
+
+function processDirectory(dirPath) {
+  try {
+    const items = readdirSync(dirPath);
+
+    for (const item of items) {
+      const fullPath = join(dirPath, item);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        processDirectory(fullPath);
+      } else if (item.endsWith(".html") || item.endsWith(".css") || item.endsWith(".js")) {
+        processFile(fullPath);
+      }
+    }
+  } catch (error) {
+    console.error(`❌ 处理目录失败: ${dirPath}`, error.message);
+  }
+}
+
+try {
+  // 第一步：执行构建
+  console.log("📦 步骤1: 执行VitePress构建...");
+  execSync("npm run build", {
+    cwd: docsDir,
+    stdio: "inherit",
+  });
+
+  // 第二步：修复路径
+  console.log("🔧 步骤2: 修复路径用于nginx部署...");
+  const distDir = join(docsDir, ".vitepress", "dist");
+  console.log("📁 目标目录:", distDir);
+
+  processDirectory(distDir);
+
+  console.log("✅ nginx构建完成！");
+  console.log("🌐 现在可以部署到nginx根路径了");
+  console.log("");
+  console.log("💡 部署说明:");
+  console.log("1. 将 .vitepress/dist/ 目录下的所有文件复制到nginx根目录");
+  console.log("2. 确保nginx配置了 try_files $uri $uri/ /index.html;");
+  console.log("3. 重启nginx服务");
+} catch (error) {
+  console.error("❌ 构建失败:", error.message);
+  process.exit(1);
+}

--- a/docs/scripts/nginx-deploy.md
+++ b/docs/scripts/nginx-deploy.md
@@ -1,0 +1,41 @@
+# Nginx部署说明
+
+## 使用方法
+
+1. **构建适合nginx的版本**：
+
+   ```bash
+   pnpm run docs:nginx
+   ```
+
+   > **注意**: 如果遇到pnpm版本问题，请确保使用Node.js v18+版本：
+   >
+   > ```bash
+   > nvm use v18.20.8  # 或更高版本
+   > ```
+
+2. **部署到nginx**：
+
+   - 将 `docs/.vitepress/dist/` 目录下的所有文件复制到nginx根目录
+   - 确保nginx配置了 `try_files $uri $uri/ /index.html;`
+
+3. **nginx配置示例**：
+   ```nginx
+   server {
+       listen 80;
+       server_name your-domain.com;
+       root /path/to/your/dist;
+       index index.html;
+
+       location / {
+           try_files $uri $uri/ /index.html;
+       }
+   }
+   ```
+
+## 特点
+
+- ✅ 不影响现有的GitHub Pages和Cloudflare Pages部署
+- ✅ 自动修复所有资源路径从 `/universal-iot-docs/` 改为 `/`
+- ✅ 支持SPA路由
+- ✅ 简单易用，一键构建

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "rimraf dist",
     "docs:dev": "pnpm run -C docs dev",
     "docs:build": "pnpm run -C docs build",
+    "docs:nginx": "pnpm run -C docs build:nginx",
     "docs:preview": "pnpm run -C docs preview",
     "docs:baiduPush": "pnpm run -C docs baiduPush",
     "to:build": "pnpm run -C build",


### PR DESCRIPTION
- 新增 pnpm run docs:nginx 命令
- 添加 build-nginx.js 脚本，一键完成构建和路径修复
- 自动修复所有资源路径从 /universal-iot-docs/ 改为 /
- 不影响现有的GitHub Pages和Cloudflare Pages部署
- 支持本地nginx部署，解决404问题